### PR TITLE
T06: Feature- User can query a list of job pagination by using offset and limit parameters

### DIFF
--- a/src/api/job.js
+++ b/src/api/job.js
@@ -141,4 +141,31 @@ router.get('/', async (request, response) => {
   }
 });
 
+router.get('/pagination', async (request, response) => {
+  try {
+    const offset = request.query.offset;
+    const limit = request.query.limit;
+    const result = await Job.paginationGet(offset, limit);
+    if (!result) {
+      return response
+        .status(400)
+        .json({message: 'Get list of jobs paginated failed!'});
+    }
+
+    return response.status(200).json({
+      message:
+        'Get list of jobs paginated successful, the list is below! There is / are ' +
+        result.jobs.length +
+        ' in total!',
+      result
+    });
+  } catch (error) {
+    console.error(`getJob() >> Error: ${error.stack}`);
+
+    response
+      .status(500)
+      .json({message: 'Get list of jobs paginated failed! ' + error.stack});
+  }
+});
+
 module.exports = router;

--- a/src/api/job.js
+++ b/src/api/job.js
@@ -120,32 +120,9 @@ router.delete('/', async (request, response) => {
 
 router.get('/', async (request, response) => {
   try {
-    const jobs = await Job.get();
-    if (!jobs) {
-      return response.status(400).json({message: 'Get all of jobs failed!'});
-    }
-
-    return response.status(200).json({
-      message:
-        'Get all jobs successful, list of jobs is below! There is / are ' +
-        jobs.length +
-        ' in total!',
-      jobs
-    });
-  } catch (error) {
-    console.error(`getJob() >> Error: ${error.stack}`);
-
-    response
-      .status(500)
-      .json({message: 'Get all of jobs failed! ' + error.stack});
-  }
-});
-
-router.get('/pagination', async (request, response) => {
-  try {
     const offset = request.query.offset;
     const limit = request.query.limit;
-    const result = await Job.paginationGet(offset, limit);
+    const result = await Job.get(offset, limit);
     if (!result) {
       return response
         .status(400)

--- a/src/persistence/job.js
+++ b/src/persistence/job.js
@@ -63,5 +63,13 @@ module.exports = {
         SELECT * FROM jobs
         `);
     return rows;
+  },
+  async paginationGet(offset, limit) {
+    if (!offset) offset = 0;
+    if (!limit) limit = 10;
+    const {rows} = await db.query(sql`
+        SELECT * FROM jobs OFFSET ${offset} LIMIT ${limit}
+        `);
+    return {jobs: rows, offset};
   }
 };

--- a/src/persistence/job.js
+++ b/src/persistence/job.js
@@ -65,11 +65,11 @@ module.exports = {
     return rows;
   },
   async paginationGet(offset, limit) {
-    if (!offset) offset = 0;
-    if (!limit) limit = 10;
+    const checkedOffset = offset || 0;
+    const checkedLimit = limit || 10;
     const {rows} = await db.query(sql`
-        SELECT * FROM jobs OFFSET ${offset} LIMIT ${limit}
+        SELECT * FROM jobs OFFSET ${checkedOffset} LIMIT ${checkedLimit}
         `);
-    return {jobs: rows, offset};
+    return {jobs: rows, checkedOffset};
   }
 };

--- a/src/persistence/job.js
+++ b/src/persistence/job.js
@@ -58,13 +58,7 @@ module.exports = {
         `);
     return rows[0];
   },
-  async get() {
-    const {rows} = await db.query(sql`
-        SELECT * FROM jobs
-        `);
-    return rows;
-  },
-  async paginationGet(offset, limit) {
+  async get(offset, limit) {
     const checkedOffset = offset || 0;
     const checkedLimit = limit || 10;
     const {rows} = await db.query(sql`

--- a/src/services/jwt.js
+++ b/src/services/jwt.js
@@ -10,7 +10,8 @@ function jwt() {
       // Public routes that don't require authentication
       '/api/sessions',
       '/api/health',
-      {url: '/api/jobs', methods: ['GET']}
+      {url: '/api/jobs', methods: ['GET']},
+      {url: '/api/jobs/pagination', methods: ['GET']}
     ]
   });
 }

--- a/src/services/jwt.js
+++ b/src/services/jwt.js
@@ -10,8 +10,7 @@ function jwt() {
       // Public routes that don't require authentication
       '/api/sessions',
       '/api/health',
-      {url: '/api/jobs', methods: ['GET']},
-      {url: '/api/jobs/pagination', methods: ['GET']}
+      {url: '/api/jobs', methods: ['GET']}
     ]
   });
 }

--- a/test/job.js
+++ b/test/job.js
@@ -184,23 +184,23 @@ describe('/CREATE, UPDATE, DELETE AND GET JOB', () => {
           response.body.should.have
             .property('message')
             .eql(
-              'Get all jobs successful, list of jobs is below! There is / are ' +
-                response.body.jobs.length +
+              'Get list of jobs paginated successful, the list is below! There is / are ' +
+                response.body.result.jobs.length +
                 ' in total!'
             );
-          for (let i = 0; i < response.body.jobs.length; i++) {
-            expect(response.body.jobs[i]).to.be.a.jsonObj();
-            response.body.jobs[i].should.have.property('id');
-            response.body.jobs[i].should.have.property('title');
-            response.body.jobs[i].should.have.property('salary_range');
-            response.body.jobs[i].should.have.property('description');
-            response.body.jobs[i].should.have.property('create_at');
-            response.body.jobs[i].should.have.property('tags');
-            expect(Array.isArray(response.body.jobs[i].tags)).to.deep.equal(
-              true
-            );
-            response.body.jobs[i].should.have.property('company');
-            response.body.jobs[i].should.have.property('logo_url');
+          for (let i = 0; i < response.body.result.jobs.length; i++) {
+            expect(response.body.result.jobs[i]).to.be.a.jsonObj();
+            response.body.result.jobs[i].should.have.property('id');
+            response.body.result.jobs[i].should.have.property('title');
+            response.body.result.jobs[i].should.have.property('salary_range');
+            response.body.result.jobs[i].should.have.property('description');
+            response.body.result.jobs[i].should.have.property('create_at');
+            response.body.result.jobs[i].should.have.property('tags');
+            expect(
+              Array.isArray(response.body.result.jobs[i].tags)
+            ).to.deep.equal(true);
+            response.body.result.jobs[i].should.have.property('company');
+            response.body.result.jobs[i].should.have.property('logo_url');
           }
 
           done();
@@ -211,7 +211,7 @@ describe('/CREATE, UPDATE, DELETE AND GET JOB', () => {
       const limit = 5;
       chai
         .request(app())
-        .get('/api/jobs/pagination?offset=' + offset + '&limit=' + limit)
+        .get('/api/jobs?offset=' + offset + '&limit=' + limit)
         .end((err, response) => {
           response.should.have.status(200);
           response.body.should.have
@@ -246,7 +246,7 @@ describe('/CREATE, UPDATE, DELETE AND GET JOB', () => {
     it('return status 200 and a list all of jobs paginated according to default offset and limit parameters in case both are not set when get the jobs successful!', (done) => {
       chai
         .request(app())
-        .get('/api/jobs/pagination')
+        .get('/api/jobs')
         .end((err, response) => {
           response.should.have.status(200);
           response.body.should.have
@@ -282,7 +282,7 @@ describe('/CREATE, UPDATE, DELETE AND GET JOB', () => {
       const limit = 5;
       chai
         .request(app())
-        .get('/api/jobs/pagination?&limit=' + limit)
+        .get('/api/jobs?&limit=' + limit)
         .end((err, response) => {
           response.should.have.status(200);
           response.body.should.have
@@ -318,7 +318,7 @@ describe('/CREATE, UPDATE, DELETE AND GET JOB', () => {
       const offset = 1;
       chai
         .request(app())
-        .get('/api/jobs/pagination?offset=' + offset)
+        .get('/api/jobs?offset=' + offset)
         .end((err, response) => {
           response.should.have.status(200);
           response.body.should.have

--- a/test/job.js
+++ b/test/job.js
@@ -30,20 +30,22 @@ describe('/CREATE, UPDATE, DELETE AND GET JOB', () => {
         accessToken = response.body.token;
         done();
       });
-    const jobParameters = {
-      title: 'Test',
-      salaryRange: '$450-$700',
-      description: 'Work with customers and dev team',
-      tags: ['English', 'Communicate', 'Technical knowledge'],
-      company: 'Faba',
-      logoURL:
-        'https://images.unsplash.com/photo-1593642632559-0c6d3fc62b89?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1950&q=80'
-    };
-    id.push(uuidv4());
-    db.query(sql`
+    for (let i = 0; i < 12; i++) {
+      const jobParameters = {
+        title: i,
+        salaryRange: '$450-$700',
+        description: 'Work with customers and dev team',
+        tags: ['English', 'Communicate', 'Technical knowledge'],
+        company: 'Faba',
+        logoURL:
+          'https://images.unsplash.com/photo-1593642632559-0c6d3fc62b89?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1950&q=80'
+      };
+      id.push(uuidv4());
+      db.query(sql`
         INSERT INTO jobs
-        VALUES (${id[0]}, ${jobParameters.title}, ${jobParameters.salaryRange}, ${jobParameters.description}, current_date, ${jobParameters.tags}, ${jobParameters.company}, ${jobParameters.logoURL})
+        VALUES (${id[i]}, ${jobParameters.title}, ${jobParameters.salaryRange}, ${jobParameters.description}, current_date, ${jobParameters.tags}, ${jobParameters.company}, ${jobParameters.logoURL})
         `);
+    }
   });
 
   describe('/POST Post a new job', () => {
@@ -199,6 +201,150 @@ describe('/CREATE, UPDATE, DELETE AND GET JOB', () => {
             );
             response.body.jobs[i].should.have.property('company');
             response.body.jobs[i].should.have.property('logo_url');
+          }
+
+          done();
+        });
+    });
+    it('return status 200 and a list all of jobs paginated according to offset and limit parameters when get the jobs successful!', (done) => {
+      const offset = 1;
+      const limit = 5;
+      chai
+        .request(app())
+        .get('/api/jobs/pagination?offset=' + offset + '&limit=' + limit)
+        .end((err, response) => {
+          response.should.have.status(200);
+          response.body.should.have
+            .property('message')
+            .eql(
+              'Get list of jobs paginated successful, the list is below! There is / are ' +
+                response.body.result.jobs.length +
+                ' in total!'
+            );
+          expect(response.body.result.jobs.length).to.deep.equal(limit);
+          expect(
+            Number.parseInt(response.body.result.offset, 10)
+          ).to.deep.equal(offset);
+          for (let i = 0; i < response.body.result.jobs.length; i++) {
+            expect(response.body.result.jobs[i]).to.be.a.jsonObj();
+            response.body.result.jobs[i].should.have.property('id');
+            response.body.result.jobs[i].should.have.property('title');
+            response.body.result.jobs[i].should.have.property('salary_range');
+            response.body.result.jobs[i].should.have.property('description');
+            response.body.result.jobs[i].should.have.property('create_at');
+            response.body.result.jobs[i].should.have.property('tags');
+            expect(
+              Array.isArray(response.body.result.jobs[i].tags)
+            ).to.deep.equal(true);
+            response.body.result.jobs[i].should.have.property('company');
+            response.body.result.jobs[i].should.have.property('logo_url');
+          }
+
+          done();
+        });
+    });
+    it('return status 200 and a list all of jobs paginated according to default offset and limit parameters in case both are not set when get the jobs successful!', (done) => {
+      chai
+        .request(app())
+        .get('/api/jobs/pagination')
+        .end((err, response) => {
+          response.should.have.status(200);
+          response.body.should.have
+            .property('message')
+            .eql(
+              'Get list of jobs paginated successful, the list is below! There is / are ' +
+                response.body.result.jobs.length +
+                ' in total!'
+            );
+          expect(response.body.result.jobs.length).to.deep.equal(10);
+          expect(
+            Number.parseInt(response.body.result.offset, 10)
+          ).to.deep.equal(0);
+          for (let i = 0; i < response.body.result.jobs.length; i++) {
+            expect(response.body.result.jobs[i]).to.be.a.jsonObj();
+            response.body.result.jobs[i].should.have.property('id');
+            response.body.result.jobs[i].should.have.property('title');
+            response.body.result.jobs[i].should.have.property('salary_range');
+            response.body.result.jobs[i].should.have.property('description');
+            response.body.result.jobs[i].should.have.property('create_at');
+            response.body.result.jobs[i].should.have.property('tags');
+            expect(
+              Array.isArray(response.body.result.jobs[i].tags)
+            ).to.deep.equal(true);
+            response.body.result.jobs[i].should.have.property('company');
+            response.body.result.jobs[i].should.have.property('logo_url');
+          }
+
+          done();
+        });
+    });
+    it('return status 200 and a list all of jobs paginated according to default offset parameters in case it is not set when get the jobs successful!', (done) => {
+      const limit = 5;
+      chai
+        .request(app())
+        .get('/api/jobs/pagination?&limit=' + limit)
+        .end((err, response) => {
+          response.should.have.status(200);
+          response.body.should.have
+            .property('message')
+            .eql(
+              'Get list of jobs paginated successful, the list is below! There is / are ' +
+                response.body.result.jobs.length +
+                ' in total!'
+            );
+          expect(response.body.result.jobs.length).to.deep.equal(limit);
+          expect(
+            Number.parseInt(response.body.result.offset, 10)
+          ).to.deep.equal(0);
+          for (let i = 0; i < response.body.result.jobs.length; i++) {
+            expect(response.body.result.jobs[i]).to.be.a.jsonObj();
+            response.body.result.jobs[i].should.have.property('id');
+            response.body.result.jobs[i].should.have.property('title');
+            response.body.result.jobs[i].should.have.property('salary_range');
+            response.body.result.jobs[i].should.have.property('description');
+            response.body.result.jobs[i].should.have.property('create_at');
+            response.body.result.jobs[i].should.have.property('tags');
+            expect(
+              Array.isArray(response.body.result.jobs[i].tags)
+            ).to.deep.equal(true);
+            response.body.result.jobs[i].should.have.property('company');
+            response.body.result.jobs[i].should.have.property('logo_url');
+          }
+
+          done();
+        });
+    });
+    it('return status 200 and a list all of jobs paginated according default limit parameters in case it is not set when get the jobs successful!', (done) => {
+      const offset = 1;
+      chai
+        .request(app())
+        .get('/api/jobs/pagination?offset=' + offset)
+        .end((err, response) => {
+          response.should.have.status(200);
+          response.body.should.have
+            .property('message')
+            .eql(
+              'Get list of jobs paginated successful, the list is below! There is / are ' +
+                response.body.result.jobs.length +
+                ' in total!'
+            );
+          expect(response.body.result.jobs.length).to.deep.equal(10);
+          expect(
+            Number.parseInt(response.body.result.offset, 10)
+          ).to.deep.equal(offset);
+          for (let i = 0; i < response.body.result.jobs.length; i++) {
+            expect(response.body.result.jobs[i]).to.be.a.jsonObj();
+            response.body.result.jobs[i].should.have.property('id');
+            response.body.result.jobs[i].should.have.property('title');
+            response.body.result.jobs[i].should.have.property('salary_range');
+            response.body.result.jobs[i].should.have.property('description');
+            response.body.result.jobs[i].should.have.property('create_at');
+            response.body.result.jobs[i].should.have.property('tags');
+            expect(
+              Array.isArray(response.body.result.jobs[i].tags)
+            ).to.deep.equal(true);
+            response.body.result.jobs[i].should.have.property('company');
+            response.body.result.jobs[i].should.have.property('logo_url');
           }
 
           done();

--- a/test/job.js
+++ b/test/job.js
@@ -223,7 +223,7 @@ describe('/CREATE, UPDATE, DELETE AND GET JOB', () => {
             );
           expect(response.body.result.jobs.length).to.deep.equal(limit);
           expect(
-            Number.parseInt(response.body.result.offset, 10)
+            Number.parseInt(response.body.result.checkedOffset, 10)
           ).to.deep.equal(offset);
           for (let i = 0; i < response.body.result.jobs.length; i++) {
             expect(response.body.result.jobs[i]).to.be.a.jsonObj();
@@ -258,7 +258,7 @@ describe('/CREATE, UPDATE, DELETE AND GET JOB', () => {
             );
           expect(response.body.result.jobs.length).to.deep.equal(10);
           expect(
-            Number.parseInt(response.body.result.offset, 10)
+            Number.parseInt(response.body.result.checkedOffset, 10)
           ).to.deep.equal(0);
           for (let i = 0; i < response.body.result.jobs.length; i++) {
             expect(response.body.result.jobs[i]).to.be.a.jsonObj();
@@ -294,7 +294,7 @@ describe('/CREATE, UPDATE, DELETE AND GET JOB', () => {
             );
           expect(response.body.result.jobs.length).to.deep.equal(limit);
           expect(
-            Number.parseInt(response.body.result.offset, 10)
+            Number.parseInt(response.body.result.checkedOffset, 10)
           ).to.deep.equal(0);
           for (let i = 0; i < response.body.result.jobs.length; i++) {
             expect(response.body.result.jobs[i]).to.be.a.jsonObj();
@@ -330,7 +330,7 @@ describe('/CREATE, UPDATE, DELETE AND GET JOB', () => {
             );
           expect(response.body.result.jobs.length).to.deep.equal(10);
           expect(
-            Number.parseInt(response.body.result.offset, 10)
+            Number.parseInt(response.body.result.checkedOffset, 10)
           ).to.deep.equal(offset);
           for (let i = 0; i < response.body.result.jobs.length; i++) {
             expect(response.body.result.jobs[i]).to.be.a.jsonObj();


### PR DESCRIPTION
User can query a list of job pagination by using offset and limit parameters.
1. Use API '/api/jobs/pagination' without authentication.
2. Set offset and limit parameters by adding to URL '?offset=...&limit=...'
3. If you don't pass any parameters, the server will set offset and limit parameters to the default value (offset = 0 and limit = 10)
4. Click send and the result should be a list of jobs paginated and the offset value.

Before: 
https://onboarding-job-board-api.herokuapp.com/api/jobs

After:
![image](https://user-images.githubusercontent.com/37283758/97987205-7ae26e80-1e0d-11eb-8f79-5464261e6e58.png)
 Server link: 
![image](https://user-images.githubusercontent.com/37283758/97987220-803fb900-1e0d-11eb-8dd4-84dd87aea648.png)

Server link: https://onboarding-job-board-api.herokuapp.com/api/jobs